### PR TITLE
Bugfix: calc_stats.numeric missing an argument

### DIFF
--- a/R/calcStats.R
+++ b/R/calcStats.R
@@ -119,7 +119,8 @@ calc_stats <- function(dt, target, target_name, treat,
 #' @export
 
 calc_stats.numeric <- function(dt, target, target_name=NULL, treat,
-                               indent = '&nbsp;&nbsp;&nbsp;&nbsp;', .total_dt=NULL) {
+                               indent = '&nbsp;&nbsp;&nbsp;&nbsp;', .total_dt=NULL,
+                               pct_dec = NULL) {
   if (is.null(target_name)){
     target_name <- target
   }


### PR DESCRIPTION
I added a dummy `pct_dec = NULL` argument to calc_stats.numeric to avoid hitting an error.

The arg is not passed anywhere and doesn't impact the function behaviour (at least right now).