### PR TITLE
Issue 08 - Specify column order

### DIFF
--- a/R/calcStats.R
+++ b/R/calcStats.R
@@ -119,7 +119,8 @@ calc_stats <- function(dt, target, target_name, treat,
 #' @export
 
 calc_stats.numeric <- function(dt, target, target_name=NULL, treat,
-                               indent = '&nbsp;&nbsp;&nbsp;&nbsp;', .total_dt=NULL) {
+                               indent = '&nbsp;&nbsp;&nbsp;&nbsp;', .total_dt=NULL,
+                               pct_dec = NULL) {
   if (is.null(target_name)){
     target_name <- target
   }

--- a/R/generateTables.R
+++ b/R/generateTables.R
@@ -8,6 +8,7 @@
 #' @param indent indent to be used for display and formatting purposes
 #' @param .total_dt optional table for total counts to be derived
 #' @param pct_dec decimal places for percentages
+#' @param treat_order customise the column order of output table
 #'
 #' @return a data.table containing summary information on target variables specified
 #' @export
@@ -49,6 +50,7 @@ summary_table <- function(dt, target, treat, target_name = NULL,
 #' @param indent indent to be used for display and formatting purposes
 #' @param .total_dt optional table for total counts to be derived
 #' @param pct_dec decimal places for percentages
+#' @param treat_order customise the column order of output table
 #'
 #' @return list containing a data.table containing summary information on target variables specified
 #' @export
@@ -103,6 +105,7 @@ summary_table_by <- function(dt, target, treat, rows_by,
 #' @param indent indent to be used for display and formatting purposes
 #' @param .total_dt optional table for total counts to be derived
 #' @param pct_dec decimal places for percentages
+#' @param treat_order customise the column order of output table
 #'
 #' @return data.table
 #' @export

--- a/R/generateTables.R
+++ b/R/generateTables.R
@@ -111,7 +111,7 @@ summary_table_by <- function(dt, target, treat, rows_by,
 #' labs <- summary_table_by_targets(adlb, c('AVAL','CHG'), 'ARM', c('PARAM','AVISIT'), '  ', NULL)
 summary_table_by_targets <- function(dt, target, treat, rows_by,
                                      indent = '&nbsp;&nbsp;&nbsp;&nbsp;',
-                                     .total_dt = NULL, pct_dec = 1){
+                                     .total_dt = NULL, pct_dec = 1, treat_order = NULL){
   if(length(target)!=2){
     print('target needs to be length 2')
   }
@@ -119,7 +119,7 @@ summary_table_by_targets <- function(dt, target, treat, rows_by,
   summary_tables <- mapply(summary_table_by, target = target,
                            MoreArgs = list(dt = dt, treat = treat, rows_by = rows_by,
                                            indent = indent, .total_dt = .total_dt,
-                                           pct_dec = pct_dec))
+                                           pct_dec = pct_dec, treat_order = treat_order))
   x <- summary_tables[[1]]
   y <- summary_tables[[2]]
   full <- x[,1]

--- a/R/generateTables.R
+++ b/R/generateTables.R
@@ -22,7 +22,7 @@
 
 summary_table <- function(dt, target, treat, target_name = NULL,
                          indent = '&nbsp;&nbsp;&nbsp;&nbsp;', .total_dt = NULL,
-                         pct_dec = 1) {
+                         pct_dec = 1, treat_order = NULL) {
   dt <- check_table(dt)
   if (is.null(target_name)){
     target_name <- target
@@ -34,6 +34,9 @@ summary_table <- function(dt, target, treat, target_name = NULL,
                                          pct_dec = pct_dec))
 
   table_summary <- data.table::rbindlist(summary_list,use.names = T)
+  if (!is.null(treat_order)) {
+    table_summary <- data.table::setcolorder(table_summary, unique(c("stats", treat_order)))
+  }
   return(table_summary)
 }
 

--- a/R/generateTables.R
+++ b/R/generateTables.R
@@ -61,7 +61,7 @@ summary_table <- function(dt, target, treat, target_name = NULL,
 
 summary_table_by <- function(dt, target, treat, rows_by,
                              indent = '&nbsp;&nbsp;&nbsp;&nbsp;',
-                             .total_dt = NULL, pct_dec = 1){
+                             .total_dt = NULL, pct_dec = 1, treat_order = NULL){
 
   dt <- check_table(dt)
   dt <- split(droplevels(dt), by = rows_by, drop = T,sorted=T)
@@ -87,7 +87,10 @@ summary_table_by <- function(dt, target, treat, rows_by,
     }
   }
   summary_split <- rbindlist(summary_split, use.names = T, fill = T)
-    return(list(summary_split))
+  if (!is.null(treat_order)) {
+    summary_split <- data.table::setcolorder(summary_split, unique(c("stats", treat_order)))
+  }
+  return(list(summary_split))
 }
 
 #' Create a summary table using multiple rows for grouping on two target column


### PR DESCRIPTION
Added argument `treat_order` to `summary_table`, `summary_table_by`, and `summary_table_by_target`.

The argument is passed to `data.table::setcolorder` to do the actual re-ordering (by reference, with no copying of data as per [the docs](https://www.rdocumentation.org/packages/data.table/versions/1.17.0/topics/setcolorder)).

`base::unique` is used to ensure that "stats" is always the first column in the output table.