### PR TITLE
Remove dtlg.data as dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dtlg
 Title: A Performance-Focused Package for Clinical Trial Tables
-Version: 0.0.2
+Version: 0.0.3
 Authors@R: c(
     person(
         given = "Max", family = "Ebenezer-Brown",
@@ -41,25 +41,23 @@ Imports:
     data.table,
     vctrs
 Suggests: 
-    dplyr,
-    random.cdisc.data,
-    rmarkdown,
-    tern,
-    kableExtra,
-    testthat (>= 3.0.0),
     bench,
-    tidyr,
+    dplyr,
+    kableExtra,
+    rmarkdown,
+    random.cdisc.data,
     rtables,
-    dtlg.data (>= 0.2.0),
+    tern,
+    testthat (>= 3.0.0),
+    tidyr,
     withr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends: 
     R (>= 4.1.0)
 Config/testthat/edition: 3
 Config/Needs/website: rmarkdown, ascentsoftware/ascentdown
-Config/Needs/check: ascentsoftware/dtlg.data
 LazyData: true
 URL: https://AscentSoftware.github.io/dtlg/
 Additional_repositories: https://ascentsoftware.r-universe.dev

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dtlg 0.0.3
+
+* Removed dependency of dtlg.data in the benchmark vignette
+
 # dtlg 0.0.2
 
 * Initial CRAN submission.

--- a/R/dt-helpers.R
+++ b/R/dt-helpers.R
@@ -38,7 +38,7 @@ dt_expand_grid <- function(..., .include_na = FALSE) {
 
 #' Count the observations in each group
 #'
-#' [dt_count()] is a simple wrapper around `data.table` commands to perform
+#' `dt_count()` is a simple wrapper around `data.table` commands to perform
 #' a count on observations in each group. Groups are defined by indicating
 #' variables to group by.
 #'
@@ -120,7 +120,7 @@ dt_count <- function(dt,
 
 #' Summarise each group down to one row
 #'
-#' [dt_summarise()] summarises a table using `data.table` as backend. Grouping
+#' `dt_summarise()` summarises a table using `data.table` as backend. Grouping
 #' is indicated with `.by` and aggregations as expressions in `...`, evaluated
 #' in the frame of `dt`.
 #'

--- a/man/print_dtlg.Rd
+++ b/man/print_dtlg.Rd
@@ -20,7 +20,7 @@ print_dtlg(
 
 \item{trunc.cols}{ If \code{TRUE}, only the columns that can be printed in the console without wrapping the columns to new lines will be printed (similar to \code{tibbles}). }
 
-\item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). }
+\item{class}{ If \code{TRUE}, the resulting output will include above each column its storage class (or a self-evident abbreviation thereof). When combined with \code{col.names="auto"} and tables >20 rows, classes will also appear at the bottom.}
 
 \item{nrows}{ The number of rows which will be printed before truncation is enforced. }
 

--- a/vignettes/articles/benchmarks.Rmd
+++ b/vignettes/articles/benchmarks.Rmd
@@ -3,7 +3,7 @@ title: "benchmarks"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{benchmarks}
-  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEngine{knitr::rmarkdown_notangle}
   %\VignetteEncoding{UTF-8}
 ---
 
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
   comment = "#>"
 )
 library(tern)
-library(dtlg.data)
+library(random.cdisc.data)
 library(dtlg)
 library(bench)
 ```
@@ -21,9 +21,11 @@ library(bench)
 ## Benchmark data
 
 ```{r}
-adsl_large <- dtlg.data::dataset("adsl_large")
-adsl_small <- dtlg.data::dataset("adsl_small")
-adae <- dtlg.data::dataset("adae")
+seed <- 42
+
+adsl_small <- random.cdisc.data::radsl(N = 20000, seed = seed)
+adsl_large <- random.cdisc.data::radsl(N = 1000000, seed = seed)
+aesi <- dtlg::aesi
 ```
 
 ## Benchmarking demographics data

--- a/vignettes/articles/benchmarks.Rmd
+++ b/vignettes/articles/benchmarks.Rmd
@@ -1,5 +1,5 @@
 ---
-title: "benchmarks"
+title: "Benchmarks"
 output: rmarkdown::html_vignette
 vignette: >
   %\VignetteIndexEntry{benchmarks}
@@ -73,9 +73,3 @@ bench::mark(
   check = FALSE
 )
 ```
-
-
-
-## Benchmarking AET02
-
-TODO


### PR DESCRIPTION
`adae` is not used in the vignette, so seemed simpler to just remove the dependency on `dtlg.data` and add the sampling in the vignette than having to work around the CRAN note.

Resolves #30